### PR TITLE
C2LC-10: add Docker definitions.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/node_modules/
+/build/
+/c2lc-exploratory.sublime-workspace
+/c2lc-exploratory.sublime-project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10-alpine as builder
+
+WORKDIR /usr/src/app
+
+COPY . ./
+
+RUN npm install
+
+RUN npx grunt build
+
+FROM nginx:alpine
+
+COPY --from=builder /usr/src/app/build /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ To run the code:
 - `npm install`
 - `grunt server`
 - Open http://localhost:8081/
+
+## Docker
+
+To build and run the code using the Docker container definitions (assuming you have Docker installed):
+
+- `docker-compose up`
+
+This builds the exploratory project in a node container, then copies the `build` directory to an nginx container for static deployment.
+
+Available environment variables: 
+- `STATIC_SITE_PORT`: controls the port mapped from the host to the port of the container's nginx service (default: 8081)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  static_site:
+    build: .
+    ports:
+      - "${STATIC_SITE_PORT:-8081}:80"
+    restart: always


### PR DESCRIPTION
This adds the necessary definitions to build and run the exploratory demo in Docker. Primary purpose is for CI-based deployment.

@simonbates - please review that the demo behaves as expected - you should be able to bring everything up from a fresh checkout using `docker-compose up` and view the site on `http://localhost:8081`.